### PR TITLE
Productize the CloudBees Jenkins Operations Center Docker image home page

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,9 @@
+# CloudBees Jenkins Operations Center Docker image
+
+This image is based on [Jenkins Official Docker image](https://registry.hub.docker.com/_/jenkins/) but runs CloudBees Jenkins Operations Center.
+
+# Building
+
+Get the war sha from Maven repo at com/cloudbees/operations-center/server/operations-center-war/${VERSION}/operations-center-war-${VERSION}.war.sha1
+
+    docker build --build-arg VERSION=1.625.16.1 --build-arg SHA=648bbc0d6020009710f8d6295254750148851f2c .

--- a/README.md
+++ b/README.md
@@ -1,9 +1,76 @@
-# CloudBees Jenkins Operation Center Docker image
+# CloudBees Jenkins Operations Center Docker image
 
-This image is based on [Jenkins Official Docker image](https://registry.hub.docker.com/_/jenkins/) but runs CloudBees Jenkins Operation Center.
+This is a fully functional [CloudBees Jenkins Operations Center](https://www.cloudbees.com/products/cloudbees-jenkins-platform).
 
-# Building
 
-Get the war sha from Maven repo at com/cloudbees/operations-center/server/operations-center-war/${VERSION}/operations-center-war-${VERSION}.war.sha1
+![CloudBees](https://www.cloudbees.com/sites/default/files/cloudbees-enterprise-notag-withbutler-logo-home.png)
 
-    docker build --build-arg VERSION=1.625.16.1 --build-arg SHA=648bbc0d6020009710f8d6295254750148851f2c .
+
+# Usage
+
+```
+docker run -p 8080:8080 -p 50000:50000 cloudbees/jenkins-operations-center
+```
+
+NOTE: read below the _build executors_ part for the role of the `50000` port mapping.
+
+This will store the workspace in /var/jenkins_home. All Jenkins data lives in there - including plugins and configuration.
+You will probably want to make that a persistent volume (recommended):
+
+```
+docker run -p 8080:8080 -p 50000:50000 -v /your/home:/var/jenkins_home cloudbees/jenkins-operations-center
+```
+
+This will store the jenkins data in `/your/home` on the host.
+Ensure that `/your/home` is accessible by the jenkins user in container (jenkins user - uid 1000) or use `-u some_other_user` parameter with `docker run`.
+
+
+You can also use a volume container:
+
+```
+docker run --name myjenkins -p 8080:8080 -p 50000:50000 -v /var/jenkins_home cloudbees/jenkins-operations-center
+```
+
+Then myjenkins container has the volume (please do read about docker volume handling to find out more).
+
+## Backing up data
+
+See [Jenkins Docker Image Documentation / Backing up data](https://hub.docker.com/_/jenkins/).
+
+# Setting the number of executors
+
+See [Jenkins Docker Image Documentation / Setting the number of executors](https://hub.docker.com/_/jenkins/).
+
+
+# Attaching build executors
+
+See [Jenkins Docker Image Documentation / Attaching build executors](https://hub.docker.com/_/jenkins/).
+
+# Passing JVM parameters
+
+See [Jenkins Docker Image Documentation / Passing JVM parameters](https://hub.docker.com/_/jenkins/).
+
+# Configuring logging
+
+See [Jenkins Docker Image Documentation / Configuring logging](https://hub.docker.com/_/jenkins/).
+
+# Passing Jenkins launcher parameters
+
+See [Jenkins Docker Image Documentation / Passing Jenkins launcher parameters](https://hub.docker.com/_/jenkins/).
+
+# Installing more tools
+
+See [Jenkins Docker Image Documentation / Installing more tools](https://hub.docker.com/_/jenkins/).
+
+## Preinstalling plugins
+
+See [Jenkins Docker Image Documentation / Preinstalling plugins](https://hub.docker.com/_/jenkins/).
+
+# Upgrading
+
+See [Jenkins Docker Image Documentation / Upgrading](https://hub.docker.com/_/jenkins/).
+
+
+# Support?
+
+Contact CloudBees support at https://support.cloudbees.com


### PR DESCRIPTION
Productive the CloudBees Jenkins Operations Center Docker image home page.

This version is the first step, we will iterate on the content to have content that is more specific to Ops Center.
