### PR TITLE
[CLTS-1042] Remove weird char and add quotes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node('dockerhub') {
     dockerCredentials = dockerhubCredentials
     warUrl = "http://jenkins-updates.cloudbees.com/download/je/${JENKINS_VERSION}/jenkins.war"
   }
-  def repo = "cloudbees/jenkins-enterprise" + (${JENKINS_VERSION}.split("\\.").length > 4 ? "-fixed" : ""​)
+  def repo = "cloudbees/jenkins-enterprise" + ("${JENKINS_VERSION}".split("\\.").length > 4 ? "-fixed" : "")
   def dockerTag = "${repo}:${JENKINS_VERSION}"
   def branch = "cje"
 


### PR DESCRIPTION
[CLTS-1042](https://cloudbees.atlassian.net/browse/CLTS-1042)

There was a weird character right before the last `)`. Could only be seen with `vi` so I missed it with sublime and/or github.

@reviewbybees 