### PR TITLE
[CLTS-1291-CJOC] allow using a local jenkins war file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,24 +11,24 @@ ARG uid=1000
 ARG gid=1000
 
 # Jenkins is run with user `jenkins`, uid = 1000
-# If you bind mount a volume from the host or a data container, 
+# If you bind mount a volume from the host or a data container,
 # ensure you use the same uid
 RUN groupadd -g ${gid} ${group} \
     && useradd -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
 
-# Jenkins home directory is a volume, so configuration and build history 
+# Jenkins home directory is a volume, so configuration and build history
 # can be persisted and survive image upgrades
 VOLUME /var/jenkins_home
 
-# `/usr/share/jenkins/ref/` contains all reference configuration we want 
-# to set on a fresh new installation. Use it to bundle additional plugins 
+# `/usr/share/jenkins/ref/` contains all reference configuration we want
+# to set on a fresh new installation. Use it to bundle additional plugins
 # or config file with your custom jenkins Docker image.
 RUN mkdir -p /usr/share/jenkins/ref/init.groovy.d
 
 ENV TINI_VERSION 0.9.0
 ENV TINI_SHA fa23d1e20732501c3bb8eeeca423c89ac80ed452
 
-# Use tini as subreaper in Docker container to adopt zombie processes 
+# Use tini as subreaper in Docker container to adopt zombie processes
 RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && chmod +x /bin/tini \
   && echo "$TINI_SHA  /bin/tini" | sha1sum -c -
 
@@ -41,13 +41,13 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.19.2}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=32b8bd1a86d6d4a91889bd38fb665db4090db081
 
-# Can be used to customize where jenkins.war get downloaded from
+# Can be used to customize where jenkins.war get downloaded/copied from
 ARG JENKINS_URL=https://jenkins-updates.cloudbees.com/download/oc/$JENKINS_VERSION/jenkins.war
 
-# could use ADD but this one does not check Last-Modified header neither does it allow to control checksum 
-# see https://github.com/docker/docker/issues/8331
-RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
-  && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha1sum -c -
+# Copy the jenkins war and check the SHA
+ADD ${JENKINS_URL} /usr/share/jenkins/jenkins.war
+RUN echo "${JENKINS_SHA} /usr/share/jenkins/jenkins.war" | sha1sum -c -
+RUN chown ${user} /usr/share/jenkins/jenkins.war
 
 ENV JENKINS_UC https://updates.jenkins.io
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref


### PR DESCRIPTION
Context: [CLTS-1291](https://cloudbees.atlassian.net/browse/CLTS-1291)

Similar to https://github.com/cloudbees/docker/pull/15, but for CJOC: we need to be able to generate the docker image using a local WAR file.

@reviewbybees esp @carlossg @recena 