### PR TITLE
Remove unnecessary 'chown' command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ ARG JENKINS_URL=https://jenkins-updates.cloudbees.com/download/oc/$JENKINS_VERSI
 # Copy the jenkins war and check the SHA
 ADD ${JENKINS_URL} /usr/share/jenkins/jenkins.war
 RUN echo "${JENKINS_SHA} /usr/share/jenkins/jenkins.war" | sha1sum -c -
-RUN chown ${user} /usr/share/jenkins/jenkins.war
 
 ENV JENKINS_UC https://updates.jenkins.io
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref


### PR DESCRIPTION
Same as https://github.com/cloudbees/docker/pull/20:

It seems that changing the ownership of the file wasn't needed after all, and it is bloating the image size since it builds an extra layer with the modified war.