### PR TITLE
Fix bloated size image issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ ARG JENKINS_URL=https://jenkins-updates.cloudbees.com/download/je/${JENKINS_VERS
 # Copy the jenkins war and check the SHA
 ADD ${JENKINS_URL} /usr/share/jenkins/jenkins.war
 RUN echo "${JENKINS_SHA} /usr/share/jenkins/jenkins.war" | sha1sum -c -
-RUN chown ${user} /usr/share/jenkins/jenkins.war
 
 ENV JENKINS_UC https://updates.jenkins.io
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@
 */
 node('dockerhub') {
   def internal = (INTERNAL == 'true')
-  def dockerRegistry, dockerCredentials, warUrl
+  def dockerRegistry, dockerCredentials
   if (internal) {
     dockerRegistry = internalDockerRegistry
     dockerCredentials = internalDockerCredentials
@@ -19,12 +19,11 @@ node('dockerhub') {
                       usernameVariable: 'NEXUS_USERNAME',
                       passwordVariable: 'NEXUS_PASSWORD']]) {
       sh "curl -fsSL -u ${env.NEXUS_USERNAME}:${env.NEXUS_PASSWORD} $internalMavenRepository/com/cloudbees/jenkins/main/jenkins-enterprise-war/${JENKINS_VERSION}/jenkins-enterprise-war-${JENKINS_VERSION}.war -o jenkins.war"
-      warUrl = "/jenkins.war"
     }
   } else {
     dockerRegistry = ''
     dockerCredentials = dockerhubCredentials
-    warUrl = "http://jenkins-updates.cloudbees.com/download/je/${JENKINS_VERSION}/jenkins.war"
+    sh "curl -fsSL http://jenkins-updates.cloudbees.com/download/je/${JENKINS_VERSION}/jenkins.war -o jenkins.war"
   }
   def repo = "cloudbees/jenkins-enterprise" + ("${JENKINS_VERSION}".split("\\.").length > 4 ? "-fixed" : "")
   def dockerTag = "${repo}:${JENKINS_VERSION}"
@@ -38,7 +37,7 @@ node('dockerhub') {
                  --no-cache \
                  --build-arg "JENKINS_VERSION=${JENKINS_VERSION}" \
                  --build-arg "JENKINS_SHA=${JENKINS_SHA}" \
-                 --build-arg "JENKINS_URL=${warUrl}" \
+                 --build-arg "JENKINS_URL=/jenkins.war" \
                   -t $dockerTag .
   """
   def img = docker.image(dockerTag)


### PR DESCRIPTION
Superseeds https://github.com/cloudbees/docker/pull/20

We can remove the 'chown' command as long as the file is copied from a local dir.